### PR TITLE
Update markup in tables from 1154-RR.25.1

### DIFF
--- a/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-E.adoc
+++ b/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-E.adoc
@@ -42,273 +42,276 @@ NOTE: Nothing in the manner of presentation of information in this Annex or in t
 
 == Radiocommunications between Amateur Stations (RR 25.1)
 
-[%unnumbered]
+[cols="<,^.^,^.^,^.^,^.^",options="unnumbered"]
 |===
-.2+^.^h| Administration of the country or geographical area 2+^.^h| BETWEEN STATIONS OF DIFFERENT COUNTRIES .2+^.^h| Remarks and restrictions imposed ^.^h| Form of call signs
-^.^h| Permitted ^.^h| Forbidden ^.^h| Pages
-^.^h| 1 ^.^h| 2 ^.^h| 3 ^.^h| 4 ^.^h| 5
+.2+^.^h| Administration of the country or geographical area
+2+h| BETWEEN STATIONS OF DIFFERENT COUNTRIES
+.2+h| Remarks and restrictions imposed
+h| Form of call signs
+h| Permitted h| Forbidden h| Pages
+^.^h| 1 h| 2 h| 3 h| 4 h| 5
 
-| Afghanistan ^.^| x | | {blank}footnote:table1[This administration has not explicitly given its position. In terms of the consultation procedure, it is assumed that this administration has no objections to radiocommunications between amateur stations of its country and stations of other countries (see Circular Letter CR/430 of 14 May 2018).] |
-| Alaska (State of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Albania (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Algeria (People's Democratic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 11
-| American Samoa ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Andorra (Principality of) ^.^| x | | {blank}footnote:table1[] |
-| Angola (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Anguilla ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Antigua and Barbuda ^.^| x | | {blank}footnote:table1[] |
-| Argentine Republic ^.^| x | | {blank}footnote:table1[] ^.^| 11
-| Armenia (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Aruba ^.^| x | | {blank}footnote:table1[] ^.^| 11
-| Ascension Island ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Australia ^.^| x | | ^.^| 11-12
-| Austria ^.^| x | | {blank}footnote:table1[] ^.^| 12
-| Azerbaijan (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Azores ^.^| x | | {blank}footnote:table1[] ^.^| 35-36
-| Bahamas (Commonwealth of the) ^.^| x | | {blank}footnote:table1[] ^.^| 12
-| Bahrain (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 12
-| Bangladesh (People's Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Barbados ^.^| x | | {blank}footnote:table1[] ^.^| 13
-| Belarus (Republic of) ^.^| x | | ^.^| 13
-| Belgium ^.^| x | | {blank}footnote:table1[] ^.^| 13-14
-| Belize ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Benin (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Bermuda ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Bhutan (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Bolivia (Plurinational State of) ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Bonaire, Sint Eustatius and Saba ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Bosnia and Herzegovina ^.^| x | | {blank}footnote:table1[] |
-| Botswana (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 14
-| Bouvet Island ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Brazil (Federative Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 15-16
-| British Virgin Islands ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Brunei Darussalam ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Bulgaria (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Burkina Faso ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Burundi (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Cabo Verde (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Cambodia (Kingdom of)) ^.^| x | | {blank}footnote:table1[] |
-| Cameroon (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 16
-| Canada ^.^| x | | {blank}footnote:table1[] ^.^| 16-17
-| Canary Islands ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Cayman Islands ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Central African Republic ^.^| x | | {blank}footnote:table1[] ^.^| 17
-| Chad (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 17
-| Chagos Islands (Indian Ocean) ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Chile ^.^| x | | {blank}footnote:table1[] ^.^| 17
-| China (People's Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Christmas Island (Indian Ocean) ^.^| x | | ^.^| 11-12
-| Clipperton Island ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Cocos (Keeling) Islands ^.^| x | | ^.^| 11-12
-| Colombia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 17
-| Comoros (Union of the) ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Congo (Republic of the) ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Cook Islands ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Costa Rica ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Côte d'Ivoire (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Croatia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Crozet Archipelago ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Cuba ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Curaçao ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Cyprus (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 18
-| Czech Republic ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Democratic People's Republic of Korea | ^.^| x | {blank}footnote:table1[] |
-| Democratic Republic of the Congo ^.^| x | | {blank}footnote:table1[] |
-| Denmark ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Diego Garcia ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Djibouti (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Dominica (Commonwealth of) ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Dominican Republic ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Easter Island ^.^| x | | {blank}footnote:table1[] ^.^| 17
-| Ecuador ^.^| x | | {blank}footnote:table1[] ^.^| 19-20
-| Egypt (Arab Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 20
-| El Salvador (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 20
-| Equatorial Guinea (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Eritrea | ^.^| x | {blank}footnote:table1[] |
-| Estonia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 20
-| Ethiopia (Federal Democratic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Falkland Islands (Malvinas) ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Faroe Islands ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Fiji (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Finland ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| France ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| French Polynesia ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Gabonese Republic ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Gambia (Republic of the) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Georgia ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Germany (Federal Republic of) ^.^| x | | ^.^| 22
-| Ghana ^.^| x | | {blank}footnote:table1[] ^.^| 23
-| Gibraltar ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Greece ^.^| x | | {blank}footnote:table1[] ^.^| 23
-| Greenland ^.^| x | | {blank}footnote:table1[] ^.^| 19
-| Grenada ^.^| x | | {blank}footnote:table1[] |
-| Guadeloupe (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Guam ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Guatemala (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 23
-| Guiana (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Guinea (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 23
-| Guinea-Bissau (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 23
-| Guyana ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Haiti (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Hawaii (State of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Heard and McDonald Islands ^.^| x | | ^.^| 11-12
-| Honduras (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Hong Kong (Special Administrative Region of China) ^.^| x | | {blank}footnote:table1[] |
-| Howland Island ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Hungary ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Iceland ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| India (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Indonesia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Iran (Islamic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 25
-| Iraq (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 25
-| Ireland ^.^| x | | {blank}footnote:table1[] ^.^| 25
-| Israel (State of) ^.^| x | | {blank}footnote:table1[] ^.^| 25
-| Italy ^.^| x | | {blank}footnote:table1[] ^.^| 25-26
-| Jamaica ^.^| x | | {blank}footnote:table1[] ^.^| 26
-| Japan ^.^| x | | {blank}footnote:table1[] ^.^| 26
-| Jarvis Island ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Johnston Island ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Jordan (Hashemite Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 26
-| Kazakhstan (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Kenya (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 26
-| Kerguelen Islands ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Kiribati (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Korea (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Kuwait (State of) ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Kyrgyz Republic ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Lao People's Democratic Republic ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Latvia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Lebanon ^.^| x | | Except Israel ^.^| 27
-| Lesotho (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Liberia (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Libya ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Liechtenstein (Principality of) ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Lithuania (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Luxembourg ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Macao (Special Administrative Region of China) ^.^| x | | {blank}footnote:table1[] |
-| Madagascar (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Madeira ^.^| x | | {blank}footnote:table1[] ^.^| 35
-| Malawi ^.^| x | | {blank}footnote:table1[] ^.^| 28
-| Malaysia ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Maldives (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Mali (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Malta ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Marion Island ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Marshall Islands (Republic of the) ^.^| x | | {blank}footnote:table1[] |
-| Martinique (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Mauritania (Islamic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Mauritius (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Mayotte (Territorial Collectivity of). ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Mexico ^.^| x | | {blank}footnote:table1[] ^.^| 30
-| Micronesia (Federated States of) ^.^| x | | {blank}footnote:table1[] ^.^| 30
-| Midway Islands ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Moldova (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 30-31
-| Monaco (Principality of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Mongolia ^.^| x | | {blank}footnote:table1[] |
-| Montenegro ^.^| x | | {blank}footnote:table1[] |
-| Montserrat ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Morocco (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Mozambique (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Myanmar (Union of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Namibia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Nauru (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Nepal (Federal Democratic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| Netherlands (Kingdom of the) ^.^| x | | {blank}footnote:table1[] ^.^| 31
-| New Caledonia ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| New Zealand ^.^| x | | {blank}footnote:table1[] ^.^| 32
-| Nicaragua ^.^| x | | {blank}footnote:table1[] ^.^| 32
-| Niger (Republic of the) ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Nigeria (Federal Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Niue ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Norfolk Island ^.^| x | | ^.^| 11-12
-| Northern Mariana Island (Commonwealth of the) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Norway ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Oman (Sultanate of) ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Pakistan (Islamic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 33
-| Palau (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Palmyra Island ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Panama (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Papua New Guinea ^.^| x | | {blank}footnote:table1[] ^.^| 34
-| Paraguay (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 34
-| Peru ^.^| x | | {blank}footnote:table1[] ^.^| 34
-| Philippines (Republic of the) ^.^| x | | {blank}footnote:table1[] ^.^| 34
-| Phoenix Islands ^.^| x | | {blank}footnote:table1[] ^.^| 27
-| Pitcairn Island ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Poland (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 34-35
-| Portugal ^.^| x | | {blank}footnote:table1[] ^.^| 35-36
-| Puerto Rico ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Qatar (State of) ^.^| x | | {blank}footnote:table1[] ^.^| 36
-| Reunion (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Rodrigues ^.^| x | | {blank}footnote:table1[] ^.^| 29
-| Romania ^.^| x | | {blank}footnote:table1[] ^.^| 36
-| Russian Federation ^.^| x | | {blank}footnote:table1[] ^.^| 36-37
-| Rwanda (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 37
-| Saint Barthélemy (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Saint Helena ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Saint Kitts and Nevis (Federation of ) ^.^| x | | {blank}footnote:table1[] |
-| Saint Lucia ^.^| x | | {blank}footnote:table1[] |
-| Saint Martin (French Department of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Saint Paul and Amsterdam Islands ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Saint Pierre and Miquelon (Territorial Collectivity of) ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Saint Vincent and the Grenadines ^.^| x | | {blank}footnote:table1[] |
-| Samoa (Independent State of) ^.^| x | | {blank}footnote:table1[] ^.^| 37
-| San Marino (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 37
-| Sao Tome and Principe (Democratic Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 37
-| Saudi Arabia (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 37
-| Senegal (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Serbia (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Seychelles (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Sierra Leone ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Singapore (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Sint Maarten (Dutch part) ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Slovak Republic ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Slovenia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Solomon Islands ^.^| x | | {blank}footnote:table1[] ^.^| 38
-| Somalia (Federal Republic of) ^.^| x | | {blank}footnote:table1[] |
-| South Africa (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| South Soudan (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Spain ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Sri Lanka (Democratic Socialist Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Sudan (Republic of the) ^.^| x | | {blank}footnote:table1[] |
-| Suriname (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Swan Islands ^.^| x | | {blank}footnote:table1[] ^.^| 24
-| Swaziland (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Sweden ^.^| x | | {blank}footnote:table1[] ^.^| 39
-| Switzerland (Confederation of) ^.^| x | | {blank}footnote:table1[] ^.^| 40
-| Syrian Arab Republic ^.^| x | | Except Israel ^.^| 40
-| Tajikistan (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Tanzania (United Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 40
-| Thailand ^.^| x | | {blank}footnote:table1[] ^.^| 40
-| The Former Yugoslav Republic of Macedonia ^.^| x | | {blank}footnote:table1[] |
-| Timor-Leste (Democratic Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Togolese Republic ^.^| x | | {blank}footnote:table1[] |
-| Tokelau ^.^| x | | {blank}footnote:table1[] ^.^| 32
-| Tonga (Kingdom of) ^.^| x | | {blank}footnote:table1[] ^.^| 40
-| Trinidad and Tobago ^.^| x | | {blank}footnote:table1[] ^.^| 40
-| Tristan da Cunha ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Tunisia ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| Turkey ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| Turkmenistan ^.^| x | | {blank}footnote:table1[] |
-| Turks and Caicos Islands ^.^| x | | {blank}footnote:table1[] ^.^| 42
-| Tuvalu ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| Uganda (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| Ukraine ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| United Arab Emirates ^.^| x | | {blank}footnote:table1[] ^.^| 41
-| United Kingdom of Great Britain and Northern Ireland ^.^| x | | {blank}footnote:table1[] ^.^| 41-42
-| United States of America ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| United States Virgin Islands ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Uruguay (Eastern Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Uzbekistan (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Vanuatu (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Vatican City State ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Venezuela (Bolivarian Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Viet Nam (Socialist Republic of) ^.^| x |
-| Except between amateur-satellite service stations ^.^| 43
-| Wake Island ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Wallis and Futuna Islands ^.^| x | | {blank}footnote:table1[] ^.^| 21
-| Yemen (Republic of) ^.^| x | | {blank}footnote:table1[] |
-| Zambia (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
-| Zimbabwe (Republic of) ^.^| x | | {blank}footnote:table1[] ^.^| 43
+| Afghanistan | x | | {blank}footnote:table1[This administration has not explicitly given its position. In terms of the consultation procedure, it is assumed that this administration has no objections to radiocommunications between amateur stations of its country and stations of other countries (see Circular Letter CR/430 of 14 May 2018).] |
+| Alaska (State of) | x | | {blank}footnote:table1[] | 43
+| Albania (Republic of) | x | | {blank}footnote:table1[] |
+| Algeria (People's Democratic Republic of) | x | | {blank}footnote:table1[] | 11
+| American Samoa | x | | {blank}footnote:table1[] | 43
+| Andorra (Principality of) | x | | {blank}footnote:table1[] |
+| Angola (Republic of) | x | | {blank}footnote:table1[] |
+| Anguilla | x | | {blank}footnote:table1[] | 42
+| Antigua and Barbuda | x | | {blank}footnote:table1[] |
+| Argentine Republic | x | | {blank}footnote:table1[] | 11
+| Armenia (Republic of) | x | | {blank}footnote:table1[] |
+| Aruba | x | | {blank}footnote:table1[] | 11
+| Ascension Island | x | | {blank}footnote:table1[] | 42
+| Australia | x | | | 11-12
+| Austria | x | | {blank}footnote:table1[] | 12
+| Azerbaijan (Republic of) | x | | {blank}footnote:table1[] |
+| Azores | x | | {blank}footnote:table1[] | 35-36
+| Bahamas (Commonwealth of the) | x | | {blank}footnote:table1[] | 12
+| Bahrain (Kingdom of) | x | | {blank}footnote:table1[] | 12
+| Bangladesh (People's Republic of) | x | | {blank}footnote:table1[] |
+| Barbados | x | | {blank}footnote:table1[] | 13
+| Belarus (Republic of) | x | | | 13
+| Belgium | x | | {blank}footnote:table1[] | 13-14
+| Belize | x | | {blank}footnote:table1[] | 14
+| Benin (Republic of) | x | | {blank}footnote:table1[] | 14
+| Bermuda | x | | {blank}footnote:table1[] | 42
+| Bhutan (Kingdom of) | x | | {blank}footnote:table1[] | 14
+| Bolivia (Plurinational State of) | x | | {blank}footnote:table1[] | 14
+| Bonaire, Sint Eustatius and Saba | x | | {blank}footnote:table1[] | 14
+| Bosnia and Herzegovina | x | | {blank}footnote:table1[] |
+| Botswana (Republic of) | x | | {blank}footnote:table1[] | 14
+| Bouvet Island | x | | {blank}footnote:table1[] | 33
+| Brazil (Federative Republic of) | x | | {blank}footnote:table1[] | 15-16
+| British Virgin Islands | x | | {blank}footnote:table1[] | 42
+| Brunei Darussalam | x | | {blank}footnote:table1[] | 16
+| Bulgaria (Republic of) | x | | {blank}footnote:table1[] | 16
+| Burkina Faso | x | | {blank}footnote:table1[] | 16
+| Burundi (Republic of) | x | | {blank}footnote:table1[] | 16
+| Cabo Verde (Republic of) | x | | {blank}footnote:table1[] | 16
+| Cambodia (Kingdom of)) | x | | {blank}footnote:table1[] |
+| Cameroon (Republic of) | x | | {blank}footnote:table1[] | 16
+| Canada | x | | {blank}footnote:table1[] | 16-17
+| Canary Islands | x | | {blank}footnote:table1[] | 39
+| Cayman Islands | x | | {blank}footnote:table1[] | 42
+| Central African Republic | x | | {blank}footnote:table1[] | 17
+| Chad (Republic of) | x | | {blank}footnote:table1[] | 17
+| Chagos Islands (Indian Ocean) | x | | {blank}footnote:table1[] | 42
+| Chile | x | | {blank}footnote:table1[] | 17
+| China (People's Republic of) | x | | {blank}footnote:table1[] |
+| Christmas Island (Indian Ocean) | x | | | 11-12
+| Clipperton Island | x | | {blank}footnote:table1[] | 21
+| Cocos (Keeling) Islands | x | | | 11-12
+| Colombia (Republic of) | x | | {blank}footnote:table1[] | 17
+| Comoros (Union of the) | x | | {blank}footnote:table1[] | 18
+| Congo (Republic of the) | x | | {blank}footnote:table1[] | 18
+| Cook Islands | x | | {blank}footnote:table1[] | 18
+| Costa Rica | x | | {blank}footnote:table1[] | 18
+| Côte d'Ivoire (Republic of) | x | | {blank}footnote:table1[] | 18
+| Croatia (Republic of) | x | | {blank}footnote:table1[] | 18
+| Crozet Archipelago | x | | {blank}footnote:table1[] | 21
+| Cuba | x | | {blank}footnote:table1[] | 18
+| Curaçao | x | | {blank}footnote:table1[] | 18
+| Cyprus (Republic of) | x | | {blank}footnote:table1[] | 18
+| Czech Republic | x | | {blank}footnote:table1[] | 19
+| Democratic People's Republic of Korea | | x | {blank}footnote:table1[] |
+| Democratic Republic of the Congo | x | | {blank}footnote:table1[] |
+| Denmark | x | | {blank}footnote:table1[] | 19
+| Diego Garcia | x | | {blank}footnote:table1[] | 42
+| Djibouti (Republic of) | x | | {blank}footnote:table1[] | 19
+| Dominica (Commonwealth of) | x | | {blank}footnote:table1[] | 19
+| Dominican Republic | x | | {blank}footnote:table1[] | 19
+| Easter Island | x | | {blank}footnote:table1[] | 17
+| Ecuador | x | | {blank}footnote:table1[] | 19-20
+| Egypt (Arab Republic of) | x | | {blank}footnote:table1[] | 20
+| El Salvador (Republic of) | x | | {blank}footnote:table1[] | 20
+| Equatorial Guinea (Republic of) | x | | {blank}footnote:table1[] |
+| Eritrea | | x | {blank}footnote:table1[] |
+| Estonia (Republic of) | x | | {blank}footnote:table1[] | 20
+| Ethiopia (Federal Democratic Republic of) | x | | {blank}footnote:table1[] | 21
+| Falkland Islands (Malvinas) | x | | {blank}footnote:table1[] | 42
+| Faroe Islands | x | | {blank}footnote:table1[] | 19
+| Fiji (Republic of) | x | | {blank}footnote:table1[] | 21
+| Finland | x | | {blank}footnote:table1[] | 21
+| France | x | | {blank}footnote:table1[] | 21
+| French Polynesia | x | | {blank}footnote:table1[] | 21
+| Gabonese Republic | x | | {blank}footnote:table1[] | 21
+| Gambia (Republic of the) | x | | {blank}footnote:table1[] | 21
+| Georgia | x | | {blank}footnote:table1[] | 21
+| Germany (Federal Republic of) | x | | | 22
+| Ghana | x | | {blank}footnote:table1[] | 23
+| Gibraltar | x | | {blank}footnote:table1[] | 42
+| Greece | x | | {blank}footnote:table1[] | 23
+| Greenland | x | | {blank}footnote:table1[] | 19
+| Grenada | x | | {blank}footnote:table1[] |
+| Guadeloupe (French Department of) | x | | {blank}footnote:table1[] | 21
+| Guam | x | | {blank}footnote:table1[] | 43
+| Guatemala (Republic of) | x | | {blank}footnote:table1[] | 23
+| Guiana (French Department of) | x | | {blank}footnote:table1[] | 21
+| Guinea (Republic of) | x | | {blank}footnote:table1[] | 23
+| Guinea-Bissau (Republic of) | x | | {blank}footnote:table1[] | 23
+| Guyana | x | | {blank}footnote:table1[] | 24
+| Haiti (Republic of) | x | | {blank}footnote:table1[] | 24
+| Hawaii (State of) | x | | {blank}footnote:table1[] | 43
+| Heard and McDonald Islands | x | | | 11-12
+| Honduras (Republic of) | x | | {blank}footnote:table1[] | 24
+| Hong Kong (Special Administrative Region of China) | x | | {blank}footnote:table1[] |
+| Howland Island | x | | {blank}footnote:table1[] | 43
+| Hungary | x | | {blank}footnote:table1[] | 24
+| Iceland | x | | {blank}footnote:table1[] | 24
+| India (Republic of) | x | | {blank}footnote:table1[] | 24
+| Indonesia (Republic of) | x | | {blank}footnote:table1[] | 24
+| Iran (Islamic Republic of) | x | | {blank}footnote:table1[] | 25
+| Iraq (Republic of) | x | | {blank}footnote:table1[] | 25
+| Ireland | x | | {blank}footnote:table1[] | 25
+| Israel (State of) | x | | {blank}footnote:table1[] | 25
+| Italy | x | | {blank}footnote:table1[] | 25-26
+| Jamaica | x | | {blank}footnote:table1[] | 26
+| Japan | x | | {blank}footnote:table1[] | 26
+| Jarvis Island | x | | {blank}footnote:table1[] | 43
+| Johnston Island | x | | {blank}footnote:table1[] | 43
+| Jordan (Hashemite Kingdom of) | x | | {blank}footnote:table1[] | 26
+| Kazakhstan (Republic of) | x | | {blank}footnote:table1[] |
+| Kenya (Republic of) | x | | {blank}footnote:table1[] | 26
+| Kerguelen Islands | x | | {blank}footnote:table1[] | 21
+| Kiribati (Republic of) | x | | {blank}footnote:table1[] | 27
+| Korea (Republic of) | x | | {blank}footnote:table1[] | 27
+| Kuwait (State of) | x | | {blank}footnote:table1[] | 27
+| Kyrgyz Republic | x | | {blank}footnote:table1[] | 27
+| Lao People's Democratic Republic | x | | {blank}footnote:table1[] | 27
+| Latvia (Republic of) | x | | {blank}footnote:table1[] | 27
+| Lebanon | x | | Except Israel | 27
+| Lesotho (Kingdom of) | x | | {blank}footnote:table1[] | 27
+| Liberia (Republic of) | x | | {blank}footnote:table1[] |
+| Libya | x | | {blank}footnote:table1[] | 28
+| Liechtenstein (Principality of) | x | | {blank}footnote:table1[] | 28
+| Lithuania (Republic of) | x | | {blank}footnote:table1[] | 28
+| Luxembourg | x | | {blank}footnote:table1[] | 28
+| Macao (Special Administrative Region of China) | x | | {blank}footnote:table1[] |
+| Madagascar (Republic of) | x | | {blank}footnote:table1[] | 28
+| Madeira | x | | {blank}footnote:table1[] | 35
+| Malawi | x | | {blank}footnote:table1[] | 28
+| Malaysia | x | | {blank}footnote:table1[] | 29
+| Maldives (Republic of) | x | | {blank}footnote:table1[] | 29
+| Mali (Republic of) | x | | {blank}footnote:table1[] |
+| Malta | x | | {blank}footnote:table1[] | 29
+| Marion Island | x | | {blank}footnote:table1[] | 39
+| Marshall Islands (Republic of the) | x | | {blank}footnote:table1[] |
+| Martinique (French Department of) | x | | {blank}footnote:table1[] | 21
+| Mauritania (Islamic Republic of) | x | | {blank}footnote:table1[] | 29
+| Mauritius (Republic of) | x | | {blank}footnote:table1[] | 29
+| Mayotte (Territorial Collectivity of). | x | | {blank}footnote:table1[] | 21
+| Mexico | x | | {blank}footnote:table1[] | 30
+| Micronesia (Federated States of) | x | | {blank}footnote:table1[] | 30
+| Midway Islands | x | | {blank}footnote:table1[] | 43
+| Moldova (Republic of) | x | | {blank}footnote:table1[] | 30-31
+| Monaco (Principality of) | x | | {blank}footnote:table1[] | 31
+| Mongolia | x | | {blank}footnote:table1[] |
+| Montenegro | x | | {blank}footnote:table1[] |
+| Montserrat | x | | {blank}footnote:table1[] | 42
+| Morocco (Kingdom of) | x | | {blank}footnote:table1[] | 31
+| Mozambique (Republic of) | x | | {blank}footnote:table1[] | 31
+| Myanmar (Union of) | x | | {blank}footnote:table1[] | 31
+| Namibia (Republic of) | x | | {blank}footnote:table1[] | 31
+| Nauru (Republic of) | x | | {blank}footnote:table1[] | 31
+| Nepal (Federal Democratic Republic of) | x | | {blank}footnote:table1[] | 31
+| Netherlands (Kingdom of the) | x | | {blank}footnote:table1[] | 31
+| New Caledonia | x | | {blank}footnote:table1[] | 21
+| New Zealand | x | | {blank}footnote:table1[] | 32
+| Nicaragua | x | | {blank}footnote:table1[] | 32
+| Niger (Republic of the) | x | | {blank}footnote:table1[] | 33
+| Nigeria (Federal Republic of) | x | | {blank}footnote:table1[] | 33
+| Niue | x | | {blank}footnote:table1[] | 33
+| Norfolk Island | x | | | 11-12
+| Northern Mariana Island (Commonwealth of the) | x | | {blank}footnote:table1[] | 43
+| Norway | x | | {blank}footnote:table1[] | 33
+| Oman (Sultanate of) | x | | {blank}footnote:table1[] | 33
+| Pakistan (Islamic Republic of) | x | | {blank}footnote:table1[] | 33
+| Palau (Republic of) | x | | {blank}footnote:table1[] |
+| Palmyra Island | x | | {blank}footnote:table1[] | 43
+| Panama (Republic of) | x | | {blank}footnote:table1[] |
+| Papua New Guinea | x | | {blank}footnote:table1[] | 34
+| Paraguay (Republic of) | x | | {blank}footnote:table1[] | 34
+| Peru | x | | {blank}footnote:table1[] | 34
+| Philippines (Republic of the) | x | | {blank}footnote:table1[] | 34
+| Phoenix Islands | x | | {blank}footnote:table1[] | 27
+| Pitcairn Island | x | | {blank}footnote:table1[] | 42
+| Poland (Republic of) | x | | {blank}footnote:table1[] | 34-35
+| Portugal | x | | {blank}footnote:table1[] | 35-36
+| Puerto Rico | x | | {blank}footnote:table1[] | 43
+| Qatar (State of) | x | | {blank}footnote:table1[] | 36
+| Reunion (French Department of) | x | | {blank}footnote:table1[] | 21
+| Rodrigues | x | | {blank}footnote:table1[] | 29
+| Romania | x | | {blank}footnote:table1[] | 36
+| Russian Federation | x | | {blank}footnote:table1[] | 36-37
+| Rwanda (Republic of) | x | | {blank}footnote:table1[] | 37
+| Saint Barthélemy (French Department of) | x | | {blank}footnote:table1[] | 21
+| Saint Helena | x | | {blank}footnote:table1[] | 42
+| Saint Kitts and Nevis (Federation of ) | x | | {blank}footnote:table1[] |
+| Saint Lucia | x | | {blank}footnote:table1[] |
+| Saint Martin (French Department of) | x | | {blank}footnote:table1[] | 21
+| Saint Paul and Amsterdam Islands | x | | {blank}footnote:table1[] | 21
+| Saint Pierre and Miquelon (Territorial Collectivity of) | x | | {blank}footnote:table1[] | 21
+| Saint Vincent and the Grenadines | x | | {blank}footnote:table1[] |
+| Samoa (Independent State of) | x | | {blank}footnote:table1[] | 37
+| San Marino (Republic of) | x | | {blank}footnote:table1[] | 37
+| Sao Tome and Principe (Democratic Republic of) | x | | {blank}footnote:table1[] | 37
+| Saudi Arabia (Kingdom of) | x | | {blank}footnote:table1[] | 37
+| Senegal (Republic of) | x | | {blank}footnote:table1[] | 38
+| Serbia (Republic of) | x | | {blank}footnote:table1[] |
+| Seychelles (Republic of) | x | | {blank}footnote:table1[] | 38
+| Sierra Leone | x | | {blank}footnote:table1[] | 38
+| Singapore (Republic of) | x | | {blank}footnote:table1[] | 38
+| Sint Maarten (Dutch part) | x | | {blank}footnote:table1[] | 38
+| Slovak Republic | x | | {blank}footnote:table1[] | 38
+| Slovenia (Republic of) | x | | {blank}footnote:table1[] | 38
+| Solomon Islands | x | | {blank}footnote:table1[] | 38
+| Somalia (Federal Republic of) | x | | {blank}footnote:table1[] |
+| South Africa (Republic of) | x | | {blank}footnote:table1[] | 39
+| South Soudan (Republic of) | x | | {blank}footnote:table1[] |
+| Spain | x | | {blank}footnote:table1[] | 39
+| Sri Lanka (Democratic Socialist Republic of) | x | | {blank}footnote:table1[] | 39
+| Sudan (Republic of the) | x | | {blank}footnote:table1[] |
+| Suriname (Republic of) | x | | {blank}footnote:table1[] | 39
+| Swan Islands | x | | {blank}footnote:table1[] | 24
+| Swaziland (Kingdom of) | x | | {blank}footnote:table1[] | 39
+| Sweden | x | | {blank}footnote:table1[] | 39
+| Switzerland (Confederation of) | x | | {blank}footnote:table1[] | 40
+| Syrian Arab Republic | x | | Except Israel | 40
+| Tajikistan (Republic of) | x | | {blank}footnote:table1[] |
+| Tanzania (United Republic of) | x | | {blank}footnote:table1[] | 40
+| Thailand | x | | {blank}footnote:table1[] | 40
+| The Former Yugoslav Republic of Macedonia | x | | {blank}footnote:table1[] |
+| Timor-Leste (Democratic Republic of) | x | | {blank}footnote:table1[] |
+| Togolese Republic | x | | {blank}footnote:table1[] |
+| Tokelau | x | | {blank}footnote:table1[] | 32
+| Tonga (Kingdom of) | x | | {blank}footnote:table1[] | 40
+| Trinidad and Tobago | x | | {blank}footnote:table1[] | 40
+| Tristan da Cunha | x | | {blank}footnote:table1[] | 42
+| Tunisia | x | | {blank}footnote:table1[] | 41
+| Turkey | x | | {blank}footnote:table1[] | 41
+| Turkmenistan | x | | {blank}footnote:table1[] |
+| Turks and Caicos Islands | x | | {blank}footnote:table1[] | 42
+| Tuvalu | x | | {blank}footnote:table1[] | 41
+| Uganda (Republic of) | x | | {blank}footnote:table1[] | 41
+| Ukraine | x | | {blank}footnote:table1[] | 41
+| United Arab Emirates | x | | {blank}footnote:table1[] | 41
+| United Kingdom of Great Britain and Northern Ireland | x | | {blank}footnote:table1[] | 41-42
+| United States of America | x | | {blank}footnote:table1[] | 43
+| United States Virgin Islands | x | | {blank}footnote:table1[] | 43
+| Uruguay (Eastern Republic of) | x | | {blank}footnote:table1[] | 43
+| Uzbekistan (Republic of) | x | | {blank}footnote:table1[] |
+| Vanuatu (Republic of) | x | | {blank}footnote:table1[] | 43
+| Vatican City State | x | | {blank}footnote:table1[] | 43
+| Venezuela (Bolivarian Republic of) | x | | {blank}footnote:table1[] | 43
+| Viet Nam (Socialist Republic of) | x |
+| Except between amateur-satellite service stations | 43
+| Wake Island | x | | {blank}footnote:table1[] | 43
+| Wallis and Futuna Islands | x | | {blank}footnote:table1[] | 21
+| Yemen (Republic of) | x | | {blank}footnote:table1[] |
+| Zambia (Republic of) | x | | {blank}footnote:table1[] | 43
+| Zimbabwe (Republic of) | x | | {blank}footnote:table1[] | 43
 
 |===
 

--- a/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-F.adoc
+++ b/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-F.adoc
@@ -43,274 +43,275 @@ NOTE: Rien dans la forme générale de cette Annexe ni dans la disposition des d
 
 == RADIOCOMMUNICATIONS ENTRE STATIONS D'AMATEUR (RR 25.1)
 
-[%unnumbered]
+[cols="<,^.^,^.^,^.^,^.^",options="unnumbered"]
 |===
-.2+^.^| Administration du pays ou zone géographique 2+^.^| ENTRE STATIONS DE PAYS DIFFERENTS .2+^.^| Remarques et restrictions imposées ^.^| Forme des indicatifs d'appel
+.2+^.^h| Administration du pays ou zone géographique
+2+h| ENTRE STATIONS DE PAYS DIFFERENTS
+.2+h| Remarques et restrictions imposées
+h| Forme des indicatifs d'appel
+h| Permises h| Interdites h| Pages
+^.^h| 1 h| 2 h| 3 h| 4 h| 5
 
-^.^| Permises ^.^| Interdites ^.^| Pages
-
-^.^| 1 ^.^| 2 ^.^| 3 ^.^| 4 ^.^| 5
-
-| Açores ^.^| x a| | {blank}footnote:res[Cette administration n'ayant pas exprimé sa position, elle est considérée ne pas s'opposer aux radiocommunications entre stations d'amateur de son pays et celles d'autres pays (voir Lettre circulaire CR/430 du 14 mai 2018).] ^.^| 36-37
-| Afghanistan ^.^| x a| | {blank}footnote:res[] a|
-| Alaska (Etat de l') ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Albanie (République d') ^.^| x a| | {blank}footnote:res[] a|
-| Algérie (République algérienne démocratique et populaire) ^.^| x | | {blank}footnote:res[] ^.^| 11
-| Allemagne (République fédérale d') ^.^| x | | ^.^| 11-12
-| Andorre (Principauté d') ^.^| x a| | {blank}footnote:res[] |
-| Angola (République d') ^.^| x a| | {blank}footnote:res[] |
-| Anguilla ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Antigua-et-Barbuda ^.^| x a| | {blank}footnote:res[] |
-| Arabie saoudite (Royaume d') ^.^| x a| | {blank}footnote:res[] ^.^| 12
-| Argentine (République) ^.^| x a| | {blank}footnote:res[] ^.^| 12
-| Arménie (République d') ^.^| x a| | {blank}footnote:res[] |
-| Aruba ^.^| x a| | {blank}footnote:res[] ^.^| 13
-| Ascension (Ile de l') ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Australie ^.^| x | | ^.^| 13
-| Autriche ^.^| x a| | {blank}footnote:res[] ^.^| 13
-| Azerbaïdjan (République d') ^.^| x a| | {blank}footnote:res[] |
-| Bahamas (Commonwealth des) ^.^| x a| | {blank}footnote:res[] ^.^| 14
-| Bahreïn (Royaume de) ^.^| x a| | {blank}footnote:res[] ^.^| 14
-| Bangladesh (République populaire du) ^.^| x a| | {blank}footnote:res[] |
-| Barbade ^.^| x a| | {blank}footnote:res[] ^.^| 14
-| Bélarus (République du) ^.^| x | | ^.^| 14
-| Belgique ^.^| x a| | {blank}footnote:res[] ^.^| 15
-| Belize ^.^| x a| | {blank}footnote:res[] ^.^| 15
-| Bénin (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 15
-| Bermudes ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Bhoutan (Royaume du) ^.^| x a| | {blank}footnote:res[] ^.^| 15
-| Bolivie (État plurinational de) ^.^| x a| | {blank}footnote:res[] ^.^| 16
-| Bonaire, Saint Eustache et Saba ^.^| x a| | {blank}footnote:res[] ^.^| 16
-| Bosnie-Herzégovine ^.^| x a| | {blank}footnote:res[] |
-| Botswana (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 16
-| Bouvet Ile ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Brésil (République fédérative du) ^.^| x a| | {blank}footnote:res[] ^.^| 16-17
-| Brunéi Darussalam ^.^| x a| | {blank}footnote:res[] ^.^| 17
-| Bulgarie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 17
-| Burkina Faso ^.^| x a| | {blank}footnote:res[] ^.^| 17
-| Burundi (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Cabo Verde (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Cambodge (Royaume du) ^.^| x a| | {blank}footnote:res[] |
-| Cameroun (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Canada ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Canaries (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| Cayman (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Centrafricaine (République) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Chagos (Iles) (Océan Indien) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Chili ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Chine (République populaire de) ^.^| x a| | {blank}footnote:res[] |
-| Christmas (Ile) (Océan Indien) ^.^| x | | ^.^| 13
-| Chypre (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Cité du Vatican (Etat de la) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Clipperton Ile ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Cocos (Keeling) (Iles) ^.^| x | | ^.^| 13
-| Colombie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Comores (Union des) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Congo (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Cook (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Corée (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Costa Rica ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Côte d'Ivoire (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Croatie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 19
-| Crozet (Archipel) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Cuba ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Curaçao ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Danemark ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Diego Garcia ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Djibouti (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Dominicaine (République) ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Dominique (Commonwealth de la) ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Egypte (République arabe d') ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| El Salvador (République d') ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| Emirats arabes unis ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| Equateur ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| Erythrée | ^.^| x | {blank}footnote:res[] |
-| Espagne ^.^| x a| | {blank}footnote:res[] ^.^| 21
-| Estonie (République d') ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Etats-Unis d'Amérique ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Ethiopie (République fédérale démocratique d') ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Falkland (Iles) (Malvinas) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Fédération de Russie ^.^| x a| | {blank}footnote:res[] ^.^| 23
-| Féroé (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Fidji (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 23
-| Finlande ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| France ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Gabonaise (République) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Gambie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Géorgie ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Ghana ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Gibraltar ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Grèce ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Grenade ^.^| x a| | {blank}footnote:res[] |
-| Groenland ^.^| x a| | {blank}footnote:res[] ^.^| 20
-| Guadeloupe (Département français de la) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Guam ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Guatemala (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Guinée (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Guinée équatoriale (République de) ^.^| x a| | {blank}footnote:res[] |
-| Guinée-Bissau (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Guyana ^.^| x a| | {blank}footnote:res[] ^.^| 25
-| Guyane (Département français de la) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Haïti (République d') ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Hawaï (Etat d') ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Heard et McDonald Iles ^.^| x | | ^.^| 13
-| Honduras (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 26
-a| Hong Kong (Région administrative spéciale de la Chine) ^.^| x | | {blank}footnote:res[] |
-| Hongrie ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Howland (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Inde (République de l') ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Indonésie (République d') ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Iran (République islamique d') ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Iraq (République d') ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Irlande ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Islande ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Israël (Etat d') ^.^| x a| | {blank}footnote:res[] ^.^| 27
-| Italie ^.^| x a| | {blank}footnote:res[] ^.^| 27
-| Jamaïque ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Japon ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Jarvis (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Johnston (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Jordanie (Royaume hachémite de) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Kazakhstan (République du) ^.^| x a| | {blank}footnote:res[] |
-| Kenya (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Kerguelen (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Kiribati (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Koweït (Etat du) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| L'ex-République yougoslave de Macédoine ^.^| x | | {blank}footnote:res[] |
-| Lao (République démocratique populaire) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Lesotho (Royaume du) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Lettonie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Liban ^.^| x | | Excepté Israël ^.^| 29
-| Libéria (République du) ^.^| x a| | {blank}footnote:res[] |
-| Libye ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Liechtenstein (Principauté de) ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Lituanie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Luxembourg ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Macao (Région administrative spéciale de la Chine) ^.^| x | | {blank}footnote:res[] |
-| Madagascar (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 29
-| Madère ^.^| x a| | {blank}footnote:res[] ^.^| 36-37
-| Malaisie ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Malawi ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Maldives (République des) ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Mali (République du) ^.^| x a| | {blank}footnote:res[] |
-| Malte ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Mariannes du Nord (Iles) (Commonwealth des) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Marion (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Maroc (Royaume du) ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Marshall (République des Iles) ^.^| x a| | {blank}footnote:res[] |
-| Martinique (Département français de la) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Maurice (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Mauritanie (République islamique de) ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Mayotte (Collectivité territoriale de) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Mexique. ^.^| x a| | {blank}footnote:res[] ^.^| 31
-| Micronésie (Etats fédérés de) ^.^| x a| | {blank}footnote:res[] ^.^| 31
-| Midway (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Moldova (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 31-32
-| Monaco (Principauté de) ^.^| x a| | {blank}footnote:res[] ^.^| 32
-| Mongolie ^.^| x a| | {blank}footnote:res[] |
-| Monténégro ^.^| x a| | {blank}footnote:res[] |
-| Montserrat ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Mozambique (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 32
-| Myanmar (Union de) ^.^| x a| | {blank}footnote:res[] ^.^| 32
-| Namibie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 32
-| Nauru (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 32
-| Népal (République fédérale démocratique du) ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Nicaragua ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Niger (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Nigéria (République fédérale du) ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Niue ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Norfolk (Ile) ^.^| x | | ^.^| 13
-| Norvège ^.^| x a| | {blank}footnote:res[] ^.^| 33
-| Nouvelle-Calédonie ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Nouvelle-Zélande ^.^| x a| | {blank}footnote:res[] ^.^| 34
-| Oman (Sultanat d') ^.^| x a| | {blank}footnote:res[] ^.^| 34
-| Ouganda (République de l') ^.^| x a| | {blank}footnote:res[] ^.^| 34
-| Ouzbékistan (République d') ^.^| x a| | {blank}footnote:res[] |
-| Pakistan (République islamique du) ^.^| x a| | {blank}footnote:res[] ^.^| 34
-| Palau (République du) ^.^| x a| | {blank}footnote:res[] |
-| Palmyra (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Panama (République du) ^.^| x a| | {blank}footnote:res[] |
-| Papouasie-Nouvelle-Guinée ^.^| x | | ^.^| 34
-| Pâques (Ile de) ^.^| x a| | {blank}footnote:res[] ^.^| 18
-| Paraguay (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 35
-| Pays-Bas (Royaume des) ^.^| x a| | {blank}footnote:res[] ^.^| 35
-| Pérou ^.^| x a| | {blank}footnote:res[] ^.^| 35
-| Philippines (République des) ^.^| x a| | {blank}footnote:res[] ^.^| 35
-| Phoenix (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 28
-| Pitcairn (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Pologne (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 35-36
-| Polynésie française ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Portugal ^.^| x a| | {blank}footnote:res[] ^.^| 36-37
-| Puerto Rico ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Qatar (Etat du) ^.^| x a| | {blank}footnote:res[] ^.^| 37
-| République arabe syrienne ^.^| x | | Excepté Israël ^.^| 37
-| République démocratique du Congo ^.^| x a| | {blank}footnote:res[] |
-| République kirghize ^.^| x a| | {blank}footnote:res[] ^.^| 37
-| République populaire démocratique de Corée | ^.^| x | {blank}footnote:res[] |
-| République slovaque ^.^| x a| | {blank}footnote:res[] ^.^| 37
-| République tchèque ^.^| x a| | {blank}footnote:res[] ^.^| 38
-| Réunion (Département français de la) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Rodrigues ^.^| x a| | {blank}footnote:res[] ^.^| 30
-| Roumanie ^.^| x a| | {blank}footnote:res[] ^.^| 38
-| Royaume-Uni de Grande-Bretagne et d'Irlande du Nord ^.^| x | | {blank}footnote:res[] ^.^| 38-39
-| Rwanda (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Saint-Barthélemy (Département français de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Sainte-Hélène ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Sainte-Lucie ^.^| x a| | {blank}footnote:res[] |
-| Saint-Kitts-et-Nevis (Fédération de) ^.^| x a| | {blank}footnote:res[] |
-| Saint-Marin (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Saint-Martin (Département français de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Saint-Martin (partie néerlandaise) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Saint-Paul-et-Amsterdam (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Saint-Pierre-et-Miquelon (Collectivité territoriale de) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Saint-Vincent-et-les-Grenadines ^.^| x a| | {blank}footnote:res[] |
-| Salomon (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Samoa (Etat indépendant du) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Samoa américaines ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Sao Tomé-et-Principe (République démocratique de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Sénégal (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Serbie (République de) ^.^| x a| | {blank}footnote:res[] |
-| Seychelles (République des) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Sierra Leone ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Singapour (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 40
-| Slovénie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Somalie (République fédérale de) ^.^| x a| | {blank}footnote:res[] |
-| Soudan (République du) ^.^| x a| | {blank}footnote:res[] |
-| Soudan du Sud (République de) ^.^| x a| | {blank}footnote:res[] |
-| Sri Lanka (République socialiste démocratique de) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Sudafricaine (République) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Suède ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Suisse (Confédération) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Suriname (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Swan (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 26
-| Swaziland (Royaume du) ^.^| x a| | {blank}footnote:res[] ^.^| 41
-| Tadjikistan (République du) ^.^| x a| | {blank}footnote:res[] |
-| Tanzanie (République-Unie de) ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Tchad (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Thaïlande ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Timor-Leste (République démocratique du) ^.^| x | | {blank}footnote:res[] |
-| Togolaise (République) ^.^| x a| | {blank}footnote:res[] |
-| Tokélau ^.^| x a| | {blank}footnote:res[] ^.^| 34
-| Tonga (Royaume des) ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Trinité-et-Tobago ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Tristan da Cunha ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Tunisie ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Turkménistan ^.^| x a| | {blank}footnote:res[] |
-| Turks et Caicos (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Turquie ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Tuvalu ^.^| x a| | {blank}footnote:res[] ^.^| 42
-| Ukraine ^.^| x a| | {blank}footnote:res[] ^.^| 43
-| Uruguay (République orientale de l') ^.^| x a| | {blank}footnote:res[] ^.^| 43
-| Vanuatu (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 43
-| Venezuela (République bolivarienne du) ^.^| x a| | {blank}footnote:res[] ^.^| 43
-| Vierges américaines (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Vierges britanniques (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 39
-| Viet Nam (République socialiste du) ^.^| x | | Excepté entre les stations du service d'amateur par satellite ^.^| 43
-| Wake (Ile) ^.^| x a| | {blank}footnote:res[] ^.^| 22
-| Wallis-et-Futuna (Iles) ^.^| x a| | {blank}footnote:res[] ^.^| 24
-| Yémen (République du) ^.^| x a| | {blank}footnote:res[] |
-| Zambie (République de) ^.^| x a| | {blank}footnote:res[] ^.^| 43
-| Zimbabwe (République du) ^.^| x a| | {blank}footnote:res[] ^.^| 43
+| Açores | x | | {blank}footnote:res[Cette administration n'ayant pas exprimé sa position, elle est considérée ne pas s'opposer aux radiocommunications entre stations d'amateur de son pays et celles d'autres pays (voir Lettre circulaire CR/430 du 14 mai 2018).] | 36-37
+| Afghanistan | x | | {blank}footnote:res[] |
+| Alaska (Etat de l') | x | | {blank}footnote:res[] | 22
+| Albanie (République d') | x | | {blank}footnote:res[] |
+| Algérie (République algérienne démocratique et populaire) | x | | {blank}footnote:res[] | 11
+| Allemagne (République fédérale d') | x | | | 11-12
+| Andorre (Principauté d') | x | | {blank}footnote:res[] |
+| Angola (République d') | x | | {blank}footnote:res[] |
+| Anguilla | x | | {blank}footnote:res[] | 39
+| Antigua-et-Barbuda | x | | {blank}footnote:res[] |
+| Arabie saoudite (Royaume d') | x | | {blank}footnote:res[] | 12
+| Argentine (République) | x | | {blank}footnote:res[] | 12
+| Arménie (République d') | x | | {blank}footnote:res[] |
+| Aruba | x | | {blank}footnote:res[] | 13
+| Ascension (Ile de l') | x | | {blank}footnote:res[] | 39
+| Australie | x | | | 13
+| Autriche | x | | {blank}footnote:res[] | 13
+| Azerbaïdjan (République d') | x | | {blank}footnote:res[] |
+| Bahamas (Commonwealth des) | x | | {blank}footnote:res[] | 14
+| Bahreïn (Royaume de) | x | | {blank}footnote:res[] | 14
+| Bangladesh (République populaire du) | x | | {blank}footnote:res[] |
+| Barbade | x | | {blank}footnote:res[] | 14
+| Bélarus (République du) | x | | | 14
+| Belgique | x | | {blank}footnote:res[] | 15
+| Belize | x | | {blank}footnote:res[] | 15
+| Bénin (République du) | x | | {blank}footnote:res[] | 15
+| Bermudes | x | | {blank}footnote:res[] | 39
+| Bhoutan (Royaume du) | x | | {blank}footnote:res[] | 15
+| Bolivie (État plurinational de) | x | | {blank}footnote:res[] | 16
+| Bonaire, Saint Eustache et Saba | x | | {blank}footnote:res[] | 16
+| Bosnie-Herzégovine | x | | {blank}footnote:res[] |
+| Botswana (République du) | x | | {blank}footnote:res[] | 16
+| Bouvet Ile | x | | {blank}footnote:res[] | 33
+| Brésil (République fédérative du) | x | | {blank}footnote:res[] | 16-17
+| Brunéi Darussalam | x | | {blank}footnote:res[] | 17
+| Bulgarie (République de) | x | | {blank}footnote:res[] | 17
+| Burkina Faso | x | | {blank}footnote:res[] | 17
+| Burundi (République du) | x | | {blank}footnote:res[] | 18
+| Cabo Verde (République de) | x | | {blank}footnote:res[] | 18
+| Cambodge (Royaume du) | x | | {blank}footnote:res[] |
+| Cameroun (République du) | x | | {blank}footnote:res[] | 18
+| Canada | x | | {blank}footnote:res[] | 18
+| Canaries (Iles) | x | | {blank}footnote:res[] | 21
+| Cayman (Iles) | x | | {blank}footnote:res[] | 39
+| Centrafricaine (République) | x | | {blank}footnote:res[] | 18
+| Chagos (Iles) (Océan Indien) | x | | {blank}footnote:res[] | 39
+| Chili | x | | {blank}footnote:res[] | 18
+| Chine (République populaire de) | x | | {blank}footnote:res[] |
+| Christmas (Ile) (Océan Indien) | x | | | 13
+| Chypre (République de) | x | | {blank}footnote:res[] | 18
+| Cité du Vatican (Etat de la) | x | | {blank}footnote:res[] | 18
+| Clipperton Ile | x | | {blank}footnote:res[] | 24
+| Cocos (Keeling) (Iles) | x | | | 13
+| Colombie (République de) | x | | {blank}footnote:res[] | 19
+| Comores (Union des) | x | | {blank}footnote:res[] | 19
+| Congo (République du) | x | | {blank}footnote:res[] | 19
+| Cook (Iles) | x | | {blank}footnote:res[] | 19
+| Corée (République de) | x | | {blank}footnote:res[] | 19
+| Costa Rica | x | | {blank}footnote:res[] | 19
+| Côte d'Ivoire (République de) | x | | {blank}footnote:res[] | 19
+| Croatie (République de) | x | | {blank}footnote:res[] | 19
+| Crozet (Archipel) | x | | {blank}footnote:res[] | 24
+| Cuba | x | | {blank}footnote:res[] | 20
+| Curaçao | x | | {blank}footnote:res[] | 20
+| Danemark | x | | {blank}footnote:res[] | 20
+| Diego Garcia | x | | {blank}footnote:res[] | 39
+| Djibouti (République de) | x | | {blank}footnote:res[] | 20
+| Dominicaine (République) | x | | {blank}footnote:res[] | 20
+| Dominique (Commonwealth de la) | x | | {blank}footnote:res[] | 20
+| Egypte (République arabe d') | x | | {blank}footnote:res[] | 21
+| El Salvador (République d') | x | | {blank}footnote:res[] | 21
+| Emirats arabes unis | x | | {blank}footnote:res[] | 21
+| Equateur | x | | {blank}footnote:res[] | 21
+| Erythrée | | x | {blank}footnote:res[] |
+| Espagne | x | | {blank}footnote:res[] | 21
+| Estonie (République d') | x | | {blank}footnote:res[] | 22
+| Etats-Unis d'Amérique | x | | {blank}footnote:res[] | 22
+| Ethiopie (République fédérale démocratique d') | x | | {blank}footnote:res[] | 22
+| Falkland (Iles) (Malvinas) | x | | {blank}footnote:res[] | 39
+| Fédération de Russie | x | | {blank}footnote:res[] | 23
+| Féroé (Iles) | x | | {blank}footnote:res[] | 20
+| Fidji (République de) | x | | {blank}footnote:res[] | 23
+| Finlande | x | | {blank}footnote:res[] | 24
+| France | x | | {blank}footnote:res[] | 24
+| Gabonaise (République) | x | | {blank}footnote:res[] | 24
+| Gambie (République de) | x | | {blank}footnote:res[] | 24
+| Géorgie | x | | {blank}footnote:res[] | 24
+| Ghana | x | | {blank}footnote:res[] | 25
+| Gibraltar | x | | {blank}footnote:res[] | 39
+| Grèce | x | | {blank}footnote:res[] | 25
+| Grenade | x | | {blank}footnote:res[] |
+| Groenland | x | | {blank}footnote:res[] | 20
+| Guadeloupe (Département français de la) | x | | {blank}footnote:res[] | 24
+| Guam | x | | {blank}footnote:res[] | 22
+| Guatemala (République du) | x | | {blank}footnote:res[] | 25
+| Guinée (République de) | x | | {blank}footnote:res[] | 25
+| Guinée équatoriale (République de) | x | | {blank}footnote:res[] |
+| Guinée-Bissau (République de) | x | | {blank}footnote:res[] | 25
+| Guyana | x | | {blank}footnote:res[] | 25
+| Guyane (Département français de la) | x | | {blank}footnote:res[] | 24
+| Haïti (République d') | x | | {blank}footnote:res[] | 26
+| Hawaï (Etat d') | x | | {blank}footnote:res[] | 22
+| Heard et McDonald Iles | x | | | 13
+| Honduras (République du) | x | | {blank}footnote:res[] | 26
+| Hong Kong (Région administrative spéciale de la Chine) | x | | {blank}footnote:res[] |
+| Hongrie | x | | {blank}footnote:res[] | 26
+| Howland (Ile) | x | | {blank}footnote:res[] | 22
+| Inde (République de l') | x | | {blank}footnote:res[] | 26
+| Indonésie (République d') | x | | {blank}footnote:res[] | 26
+| Iran (République islamique d') | x | | {blank}footnote:res[] | 26
+| Iraq (République d') | x | | {blank}footnote:res[] | 26
+| Irlande | x | | {blank}footnote:res[] | 26
+| Islande | x | | {blank}footnote:res[] | 26
+| Israël (Etat d') | x | | {blank}footnote:res[] | 27
+| Italie | x | | {blank}footnote:res[] | 27
+| Jamaïque | x | | {blank}footnote:res[] | 28
+| Japon | x | | {blank}footnote:res[] | 28
+| Jarvis (Ile) | x | | {blank}footnote:res[] | 22
+| Johnston (Ile) | x | | {blank}footnote:res[] | 22
+| Jordanie (Royaume hachémite de) | x | | {blank}footnote:res[] | 28
+| Kazakhstan (République du) | x | | {blank}footnote:res[] |
+| Kenya (République du) | x | | {blank}footnote:res[] | 28
+| Kerguelen (Iles) | x | | {blank}footnote:res[] | 24
+| Kiribati (République de) | x | | {blank}footnote:res[] | 28
+| Koweït (Etat du) | x | | {blank}footnote:res[] | 28
+| L'ex-République yougoslave de Macédoine | x | | {blank}footnote:res[] |
+| Lao (République démocratique populaire) | x | | {blank}footnote:res[] | 28
+| Lesotho (Royaume du) | x | | {blank}footnote:res[] | 28
+| Lettonie (République de) | x | | {blank}footnote:res[] | 29
+| Liban | x | | Excepté Israël | 29
+| Libéria (République du) | x | | {blank}footnote:res[] |
+| Libye | x | | {blank}footnote:res[] | 29
+| Liechtenstein (Principauté de) | x | | {blank}footnote:res[] | 29
+| Lituanie (République de) | x | | {blank}footnote:res[] | 29
+| Luxembourg | x | | {blank}footnote:res[] | 29
+| Macao (Région administrative spéciale de la Chine) | x | | {blank}footnote:res[] |
+| Madagascar (République de) | x | | {blank}footnote:res[] | 29
+| Madère | x | | {blank}footnote:res[] | 36-37
+| Malaisie | x | | {blank}footnote:res[] | 30
+| Malawi | x | | {blank}footnote:res[] | 30
+| Maldives (République des) | x | | {blank}footnote:res[] | 30
+| Mali (République du) | x | | {blank}footnote:res[] |
+| Malte | x | | {blank}footnote:res[] | 30
+| Mariannes du Nord (Iles) (Commonwealth des) | x | | {blank}footnote:res[] | 22
+| Marion (Ile) | x | | {blank}footnote:res[] | 41
+| Maroc (Royaume du) | x | | {blank}footnote:res[] | 30
+| Marshall (République des Iles) | x | | {blank}footnote:res[] |
+| Martinique (Département français de la) | x | | {blank}footnote:res[] | 24
+| Maurice (République de) | x | | {blank}footnote:res[] | 30
+| Mauritanie (République islamique de) | x | | {blank}footnote:res[] | 30
+| Mayotte (Collectivité territoriale de) | x | | {blank}footnote:res[] | 24
+| Mexique. | x | | {blank}footnote:res[] | 31
+| Micronésie (Etats fédérés de) | x | | {blank}footnote:res[] | 31
+| Midway (Iles) | x | | {blank}footnote:res[] | 22
+| Moldova (République de) | x | | {blank}footnote:res[] | 31-32
+| Monaco (Principauté de) | x | | {blank}footnote:res[] | 32
+| Mongolie | x | | {blank}footnote:res[] |
+| Monténégro | x | | {blank}footnote:res[] |
+| Montserrat | x | | {blank}footnote:res[] | 39
+| Mozambique (République du) | x | | {blank}footnote:res[] | 32
+| Myanmar (Union de) | x | | {blank}footnote:res[] | 32
+| Namibie (République de) | x | | {blank}footnote:res[] | 32
+| Nauru (République de) | x | | {blank}footnote:res[] | 32
+| Népal (République fédérale démocratique du) | x | | {blank}footnote:res[] | 32
+| Nicaragua | x | | {blank}footnote:res[] | 33
+| Niger (République du) | x | | {blank}footnote:res[] | 33
+| Nigéria (République fédérale du) | x | | {blank}footnote:res[] | 33
+| Niue | x | | {blank}footnote:res[] | 33
+| Norfolk (Ile) | x | | | 13
+| Norvège | x | | {blank}footnote:res[] | 33
+| Nouvelle-Calédonie | x | | {blank}footnote:res[] | 24
+| Nouvelle-Zélande | x | | {blank}footnote:res[] | 34
+| Oman (Sultanat d') | x | | {blank}footnote:res[] | 34
+| Ouganda (République de l') | x | | {blank}footnote:res[] | 34
+| Ouzbékistan (République d') | x | | {blank}footnote:res[] |
+| Pakistan (République islamique du) | x | | {blank}footnote:res[] | 34
+| Palau (République du) | x | | {blank}footnote:res[] |
+| Palmyra (Ile) | x | | {blank}footnote:res[] | 22
+| Panama (République du) | x | | {blank}footnote:res[] |
+| Papouasie-Nouvelle-Guinée | x | | | 34
+| Pâques (Ile de) | x | | {blank}footnote:res[] | 18
+| Paraguay (République du) | x | | {blank}footnote:res[] | 35
+| Pays-Bas (Royaume des) | x | | {blank}footnote:res[] | 35
+| Pérou | x | | {blank}footnote:res[] | 35
+| Philippines (République des) | x | | {blank}footnote:res[] | 35
+| Phoenix (Iles) | x | | {blank}footnote:res[] | 28
+| Pitcairn (Ile) | x | | {blank}footnote:res[] | 39
+| Pologne (République de) | x | | {blank}footnote:res[] | 35-36
+| Polynésie française | x | | {blank}footnote:res[] | 24
+| Portugal | x | | {blank}footnote:res[] | 36-37
+| Puerto Rico | x | | {blank}footnote:res[] | 22
+| Qatar (Etat du) | x | | {blank}footnote:res[] | 37
+| République arabe syrienne | x | | Excepté Israël | 37
+| République démocratique du Congo | x | | {blank}footnote:res[] |
+| République kirghize | x | | {blank}footnote:res[] | 37
+| République populaire démocratique de Corée | | x | {blank}footnote:res[] |
+| République slovaque | x | | {blank}footnote:res[] | 37
+| République tchèque | x | | {blank}footnote:res[] | 38
+| Réunion (Département français de la) | x | | {blank}footnote:res[] | 24
+| Rodrigues | x | | {blank}footnote:res[] | 30
+| Roumanie | x | | {blank}footnote:res[] | 38
+| Royaume-Uni de Grande-Bretagne et d'Irlande du Nord | x | | {blank}footnote:res[] | 38-39
+| Rwanda (République du) | x | | {blank}footnote:res[] | 39
+| Saint-Barthélemy (Département français de la) | x | | {blank}footnote:res[] | 24
+| Sainte-Hélène | x | | {blank}footnote:res[] | 39
+| Sainte-Lucie | x | | {blank}footnote:res[] |
+| Saint-Kitts-et-Nevis (Fédération de) | x | | {blank}footnote:res[] |
+| Saint-Marin (République de) | x | | {blank}footnote:res[] | 40
+| Saint-Martin (Département français de la) | x | | {blank}footnote:res[] | 24
+| Saint-Martin (partie néerlandaise) | x | | {blank}footnote:res[] | 40
+| Saint-Paul-et-Amsterdam (Iles) | x | | {blank}footnote:res[] | 24
+| Saint-Pierre-et-Miquelon (Collectivité territoriale de) | x | | {blank}footnote:res[] | 24
+| Saint-Vincent-et-les-Grenadines | x | | {blank}footnote:res[] |
+| Salomon (Iles) | x | | {blank}footnote:res[] | 40
+| Samoa (Etat indépendant du) | x | | {blank}footnote:res[] | 40
+| Samoa américaines | x | | {blank}footnote:res[] | 22
+| Sao Tomé-et-Principe (République démocratique de) | x | | {blank}footnote:res[] | 40
+| Sénégal (République du) | x | | {blank}footnote:res[] | 40
+| Serbie (République de) | x | | {blank}footnote:res[] |
+| Seychelles (République des) | x | | {blank}footnote:res[] | 40
+| Sierra Leone | x | | {blank}footnote:res[] | 40
+| Singapour (République de) | x | | {blank}footnote:res[] | 40
+| Slovénie (République de) | x | | {blank}footnote:res[] | 41
+| Somalie (République fédérale de) | x | | {blank}footnote:res[] |
+| Soudan (République du) | x | | {blank}footnote:res[] |
+| Soudan du Sud (République de) | x | | {blank}footnote:res[] |
+| Sri Lanka (République socialiste démocratique de) | x | | {blank}footnote:res[] | 41
+| Sudafricaine (République) | x | | {blank}footnote:res[] | 41
+| Suède | x | | {blank}footnote:res[] | 41
+| Suisse (Confédération) | x | | {blank}footnote:res[] | 41
+| Suriname (République du) | x | | {blank}footnote:res[] | 41
+| Swan (Iles) | x | | {blank}footnote:res[] | 26
+| Swaziland (Royaume du) | x | | {blank}footnote:res[] | 41
+| Tadjikistan (République du) | x | | {blank}footnote:res[] |
+| Tanzanie (République-Unie de) | x | | {blank}footnote:res[] | 42
+| Tchad (République du) | x | | {blank}footnote:res[] | 42
+| Thaïlande | x | | {blank}footnote:res[] | 42
+| Timor-Leste (République démocratique du) | x | | {blank}footnote:res[] |
+| Togolaise (République) | x | | {blank}footnote:res[] |
+| Tokélau | x | | {blank}footnote:res[] | 34
+| Tonga (Royaume des) | x | | {blank}footnote:res[] | 42
+| Trinité-et-Tobago | x | | {blank}footnote:res[] | 42
+| Tristan da Cunha | x | | {blank}footnote:res[] | 39
+| Tunisie | x | | {blank}footnote:res[] | 42
+| Turkménistan | x | | {blank}footnote:res[] |
+| Turks et Caicos (Iles) | x | | {blank}footnote:res[] | 39
+| Turquie | x | | {blank}footnote:res[] | 42
+| Tuvalu | x | | {blank}footnote:res[] | 42
+| Ukraine | x | | {blank}footnote:res[] | 43
+| Uruguay (République orientale de l') | x | | {blank}footnote:res[] | 43
+| Vanuatu (République de) | x | | {blank}footnote:res[] | 43
+| Venezuela (République bolivarienne du) | x | | {blank}footnote:res[] | 43
+| Vierges américaines (Iles) | x | | {blank}footnote:res[] | 22
+| Vierges britanniques (Iles) | x | | {blank}footnote:res[] | 39
+| Viet Nam (République socialiste du) | x | | Excepté entre les stations du service d'amateur par satellite | 43
+| Wake (Ile) | x | | {blank}footnote:res[] | 22
+| Wallis-et-Futuna (Iles) | x | | {blank}footnote:res[] | 24
+| Yémen (République du) | x | | {blank}footnote:res[] |
+| Zambie (République de) | x | | {blank}footnote:res[] | 43
+| Zimbabwe (République du) | x | | {blank}footnote:res[] | 43
 
 |===
 

--- a/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-S.adoc
+++ b/1154-RR.25.1/T-SP-RR.25.1-2018-MSW-S.adoc
@@ -44,274 +44,275 @@ NOTE: La forma de agrupar o presentar los datos adoptada en este Anexo no supone
 
 == RADIOCOMUNICACIONES ENTRE ESTACIONES DE AFICIONADO (RR 25.1)
 
-[%unnumbered]
+[cols="<,^.^,^.^,^.^,^.^",options="unnumbered"]
 |===
-.2+^.^| Administración del país o zona geográfica 2+^.^| ENTRE ESTACIONES DE PAÍSES DISTINTOS .2+^.^| Observaciones y restricciones impuestas ^.^| Forma de los distintivos de llamada
+.2+^.^h| Administración del país o zona geográfica
+2+h| ENTRE ESTACIONES DE PAÍSES DISTINTOS
+.2+h| Observaciones y restricciones impuestas
+h| Forma de los distintivos de llamada
+h| Permitidas h| Prohibidas h| Páginas
+^.^h| 1 h| 2 h| 3 h| 4 h| 5
 
-^.^| Permitidas ^.^| Prohibidas ^.^| Páginas
-
-^.^| 1 ^.^| 2 ^.^| 3 ^.^| 4 ^.^| 5
-
-| Afganistán ^.^| x | | {blank}footnote:res[Esta administración no ha manifestado explícitamente su postura. En cuanto al procedimiento de consulta se supone que la administración no ha presentado objeciones a las radiocomunicaciones entre estaciones de aficionado de su país y estaciones de otros países (véase la Carta circular CR/430 del 14 de mayo de 2018).] |
-| Alaska (Estado de) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Albania (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Alemania (República Federal de) ^.^| x | | ^.^| 11-12
-| Andorra (Principado de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Angola (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Anguilla ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Antigua y Barbuda ^.^| x | | {blank}footnote:res[] ^.^|
-| Arabia Saudita (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 12
-| Argelia (República Argelina Democrática y Popular) ^.^| x | | {blank}footnote:res[] ^.^| 12
-| Argentina (República) ^.^| x | | {blank}footnote:res[] ^.^| 12
-| Armenia (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Aruba ^.^| x | | {blank}footnote:res[] ^.^| 13
-| Ascensión (Isla de la) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Australia ^.^| x | | ^.^| 13
-| Austria ^.^| x | | {blank}footnote:res[] ^.^| 13
-| Azerbaiyán (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Azores ^.^| x | | {blank}footnote:res[] ^.^| 36-37
-| Bahamas (Commonwealth de las) ^.^| x | | {blank}footnote:res[] ^.^| 14
-| Bahrein (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 14
-| Bangladesh (República Popular de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Barbados ^.^| x | | {blank}footnote:res[] ^.^| 14
-| Belarús (República de) ^.^| x | | ^.^| 14
-| Bélgica ^.^| x | | {blank}footnote:res[] ^.^| 15
-| Belice ^.^| x | | {blank}footnote:res[] ^.^| 15
-| Benin (República de) ^.^| x | | {blank}footnote:res[] ^.^| 15
-| Bermudas ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Bhután (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 15
-| Bolivia (Estado Plurinacional de) ^.^| x | | {blank}footnote:res[] ^.^| 16
-| Bonaire, San Eustatius y Saba ^.^| x | | {blank}footnote:res[] ^.^| 16
-| Bosnia y Herzegovina ^.^| x | | {blank}footnote:res[] ^.^|
-| Botswana (República de) ^.^| x | | {blank}footnote:res[] ^.^| 16
-| Bouvet Isla ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Brasil (República Federativa del) ^.^| x | | {blank}footnote:res[] ^.^| 16-17
-| Brunei Darussalam ^.^| x | | {blank}footnote:res[] ^.^| 17
-| Bulgaria (República de) ^.^| x | | {blank}footnote:res[] ^.^| 17
-| Burkina Faso ^.^| x | | {blank}footnote:res[] ^.^| 17
-| Burundi (República de) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Cabo Verde (República de) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Caimanes (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Camboya (Reino de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Camerún (República de) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Canadá ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Canarias (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 21
-| Centroafricana (República) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Ciudad del Vaticano (Estado de la) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Clipperton Isla ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Cocos (Keeling) (Islas) ^.^| x | | ^.^| 13
-| Colombia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 18
-| Comoras (Unión de las) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Congo (República del) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Cook (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Corea (República de) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Costa Rica ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Côte d'Ivoire (República de) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Croacia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Crozet (Archipiélago) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Cuba ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Curaçao ^.^| x | | {blank}footnote:res[] ^.^| 19
-| Chad (República del) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Chagos (Islas) (Océano Índico) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Chile ^.^| x | | {blank}footnote:res[] ^.^| 20
-| China (República Popular de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Chipre (República de) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Christmas (Isla) (Océano Índico) ^.^| x | | ^.^| 13
-| Diego García ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Dinamarca ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Djibouti (República de) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Dominica (Commonwealth de) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Dominicana (República) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Ecuador ^.^| x | | {blank}footnote:res[] ^.^| 21
-| Egipto (República Árabe de) ^.^| x | | {blank}footnote:res[] ^.^| 21
-| El Salvador (República de) ^.^| x | | {blank}footnote:res[] ^.^| 21
-| Emiratos Árabes Unidos ^.^| x | | {blank}footnote:res[] ^.^| 21
-| Eritrea | ^.^| x | {blank}footnote:res[] |
-| Eslovenia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 21
-| España ^.^| x | | {blank}footnote:res[] ^.^| 21
-| Estados Unidos de América ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Estonia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Etiopía (República Democrática Federal de) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Federación de Rusia ^.^| x | | {blank}footnote:res[] ^.^| 23
-| Feroe (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Fiji (República de) ^.^| x | | {blank}footnote:res[] ^.^| 23
-| Filipinas (República de) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Finlandia ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Francia ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Gabonesa (República) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Gambia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Georgia ^.^| x | | {blank}footnote:res[] ^.^| 25
-| Ghana ^.^| x | | {blank}footnote:res[] ^.^| 25
-| Gibraltar ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Granada ^.^| x | | {blank}footnote:res[] ^.^|
-| Grecia ^.^| x | | {blank}footnote:res[] ^.^| 25
-| Groenlandia ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Guadalupe (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Guam ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Guatemala (República de) ^.^| x | | {blank}footnote:res[] ^.^| 25
-| Guayana (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Guinea (República de) ^.^| x | | {blank}footnote:res[] ^.^| 25
-| Guinea Ecuatorial (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Guinea-Bissau (República de) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Guyana ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Haití (República de) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Hawai (Estado de) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Heard y McDonald Islas ^.^| x | | ^.^| 13
-| Honduras (República de) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Hong Kong (Región administrativa especial de China) ^.^| | | {blank}footnote:res[] |
-| Howland (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Hungría ^.^| x | | {blank}footnote:res[] ^.^| 26
-| India (República de la) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Indonesia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Irán (República Islámica del) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Iraq (República del) ^.^| x | | {blank}footnote:res[] ^.^| 27
-| Irlanda ^.^| x | | {blank}footnote:res[] ^.^| 27
-| Islandia ^.^| x | | {blank}footnote:res[] ^.^| 27
-| Israel (Estado de) ^.^| x | | {blank}footnote:res[] ^.^| 27
-| Italia ^.^| x | | {blank}footnote:res[] ^.^| 27-28
-| Jamaica ^.^| x | | {blank}footnote:res[] ^.^| 28
-| Japón ^.^| x | | {blank}footnote:res[] ^.^| 28
-| Jarvis (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Johnston (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Jordania (Reino Hachemita de) ^.^| x | | {blank}footnote:res[] ^.^| 28
-| Kazajstán (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Kenya (República de) ^.^| x | | {blank}footnote:res[] ^.^| 28
-| Kerguelén (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Kiribati (República de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Kuwait (Estado de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| La ex República Yugoslava de Macedonia ^.^| x | | {blank}footnote:res[] ^.^|
-| Lao (República Democrática Popular) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Lesotho (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Letonia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Líbano ^.^| x | | Excepto Israel ^.^| 29
-| Liberia (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Libia ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Liechtenstein (Principado de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Lituania (República de) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Luxemburgo ^.^| x | | {blank}footnote:res[] ^.^| 30
-| Macao (Región administrativa especial de China) ^.^| x | | {blank}footnote:res[] |
-| Madagascar (República de) ^.^| x | | {blank}footnote:res[] ^.^| 30
-| Madeira ^.^| x | | {blank}footnote:res[] ^.^| 36
-| Malasia ^.^| x | | {blank}footnote:res[] ^.^| 30
-| Malawi ^.^| x | | {blank}footnote:res[] ^.^| 30
-| Maldivas (República de) ^.^| x | | {blank}footnote:res[] ^.^| 30
-| Malí (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Malta ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Malvinas (Islas) (Falkland) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Marianas del Norte (Islas) (Commonwealth de las) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Marión (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Marruecos (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Marshall (República de las Islas) ^.^| x | | {blank}footnote:res[] ^.^|
-| Martinica (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Mauricio (República de) ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Mauritania (República Islámica de) ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Mayotte (Colectividad territorial de). ^.^| x | | {blank}footnote:res[] ^.^| 24
-| México. ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Micronesia (Estados federados de) ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Midway (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Moldova (República de). ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Mónaco (Principado de) ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Mongolia ^.^| x | | {blank}footnote:res[] ^.^|
-| Montenegro ^.^| x | | {blank}footnote:res[] ^.^|
-| Montserrat ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Mozambique (República de) ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Myanmar (Unión de) ^.^| x | | {blank}footnote:res[] ^.^| 32
-| Namibia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Nauru (República de) ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Nepal (República Democrática Federal de) ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Nicaragua ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Níger (República del) ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Nigeria (República Federal de) ^.^| x | | {blank}footnote:res[] ^.^| 33
-| Niue ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Norfolk (Isla) ^.^| x | | ^.^| 13
-| Noruega ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Nueva Caledonia ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Nueva Zelandia ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Omán (Sultanía de) ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Países Bajos (Reino de los) ^.^| x | | {blank}footnote:res[] ^.^| 35
-| Pakistán (República Islámica del) ^.^| x | | {blank}footnote:res[] ^.^| 35
-| Palau (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Palmira (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Panamá (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Papua Nueva Guinea ^.^| x | | {blank}footnote:res[] ^.^| 35
-| Paraguay (República del) ^.^| x | | {blank}footnote:res[] ^.^| 35
-| Pascua (Isla de) ^.^| x | | {blank}footnote:res[] ^.^| 20
-| Perú ^.^| x | | {blank}footnote:res[] ^.^| 35
-| Phoenix (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 29
-| Pitcairn (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Polinesia francesa ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Polonia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 35-36
-| Portugal ^.^| x | | {blank}footnote:res[] ^.^| 36-37
-| Puerto Rico ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Qatar (Estado de) ^.^| x | | {blank}footnote:res[] ^.^| 37
-| Reino Unido de Gran Bretaña e Irlanda del Norte ^.^| x | | {blank}footnote:res[] ^.^| 37-38
-| República Árabe Siria ^.^| x | | Excepto Israel ^.^| 39
-| República Checa ^.^| x | | {blank}footnote:res[] ^.^| 39
-| República Democrática del Congo ^.^| x | | {blank}footnote:res[] ^.^|
-| República Eslovaca ^.^| x | | {blank}footnote:res[] ^.^| 39
-| República Kirguisa ^.^| x | | {blank}footnote:res[] ^.^| 39
-| República Popular Democrática de Corea | ^.^| x | {blank}footnote:res[] |
-| Reunión (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Rodrígues ^.^| x | | {blank}footnote:res[] ^.^| 31
-| Rumania ^.^| x | | {blank}footnote:res[] ^.^| 39
-| Rwanda (República de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Saint Kitts y Nevis (Federación de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Salomón (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Samoa (Estado Independiente de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Samoa norteamericanas ^.^| x | | {blank}footnote:res[] ^.^| 22
-| San Bartolomé (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| San Maarten (parte neerlandesa) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| San Marino (República de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| San Martín (Departamento francés de la) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| San Paul y Amsterdam (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| San Pedro y Miquelón (Colectividad territorial de) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| San Vicente y las Granadinas ^.^| x | | {blank}footnote:res[] ^.^|
-| Santa Elena ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Santa Lucía ^.^| x | | {blank}footnote:res[] ^.^|
-| Santo Tomé y Príncipe (República Democrática de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Senegal (República del) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Serbia (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Seychelles (República de) ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Sierra Leona ^.^| x | | {blank}footnote:res[] ^.^| 40
-| Singapur (República de) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Somalia (República Federal de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Sri Lanka (República Socialista Democrática de) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Sudafricana (República) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Sudán (República del) ^.^| x | | {blank}footnote:res[] ^.^|
-| Sudán del Sur (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Suecia ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Suiza (Confederación) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Suriname (República de) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Swan (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 26
-| Swazilandia (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 41
-| Tailandia ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Tanzanía (República Unida de) ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Tayikistán (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Timor-Leste (República Democrática de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Togolesa (República) ^.^| x | | {blank}footnote:res[] ^.^|
-| Tokelau ^.^| x | | {blank}footnote:res[] ^.^| 34
-| Tonga (Reino de) ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Trinidad y Tabago ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Tristán da Cunha ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Túnez ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Turkmenistán ^.^| x | | {blank}footnote:res[] ^.^|
-| Turquesas y Caicos (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Turquía ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Tuvalu ^.^| x | | {blank}footnote:res[] ^.^| 42
-| Ucrania ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Uganda (República de) ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Uruguay (República Oriental del) ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Uzbekistán (República de) ^.^| x | | {blank}footnote:res[] ^.^|
-| Vanuatu (República de) ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Venezuela (República Bolivariana de) ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Viet Nam (República Socialista de) ^.^| x | | Excepto entre estaciones del servicio de aficionados por satélite ^.^| 43
-| Vírgenes americanas (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Vírgenes británicas (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 38
-| Wake (Isla) ^.^| x | | {blank}footnote:res[] ^.^| 22
-| Wallis y Futuna (Islas) ^.^| x | | {blank}footnote:res[] ^.^| 24
-| Yemen (República del) ^.^| x | | {blank}footnote:res[] ^.^|
-| Zambia (República de) ^.^| x | | {blank}footnote:res[] ^.^| 43
-| Zimbabwe (República de) ^.^| x | | {blank}footnote:res[] ^.^| 43
+| Afganistán | x | | {blank}footnote:res[Esta administración no ha manifestado explícitamente su postura. En cuanto al procedimiento de consulta se supone que la administración no ha presentado objeciones a las radiocomunicaciones entre estaciones de aficionado de su país y estaciones de otros países (véase la Carta circular CR/430 del 14 de mayo de 2018).] |
+| Alaska (Estado de) | x | | {blank}footnote:res[] | 22
+| Albania (República de) | x | | {blank}footnote:res[] |
+| Alemania (República Federal de) | x | | | 11-12
+| Andorra (Principado de) | x | | {blank}footnote:res[] |
+| Angola (República de) | x | | {blank}footnote:res[] |
+| Anguilla | x | | {blank}footnote:res[] | 38
+| Antigua y Barbuda | x | | {blank}footnote:res[] |
+| Arabia Saudita (Reino de) | x | | {blank}footnote:res[] | 12
+| Argelia (República Argelina Democrática y Popular) | x | | {blank}footnote:res[] | 12
+| Argentina (República) | x | | {blank}footnote:res[] | 12
+| Armenia (República de) | x | | {blank}footnote:res[] |
+| Aruba | x | | {blank}footnote:res[] | 13
+| Ascensión (Isla de la) | x | | {blank}footnote:res[] | 38
+| Australia | x | | | 13
+| Austria | x | | {blank}footnote:res[] | 13
+| Azerbaiyán (República de) | x | | {blank}footnote:res[] |
+| Azores | x | | {blank}footnote:res[] | 36-37
+| Bahamas (Commonwealth de las) | x | | {blank}footnote:res[] | 14
+| Bahrein (Reino de) | x | | {blank}footnote:res[] | 14
+| Bangladesh (República Popular de) | x | | {blank}footnote:res[] |
+| Barbados | x | | {blank}footnote:res[] | 14
+| Belarús (República de) | x | | | 14
+| Bélgica | x | | {blank}footnote:res[] | 15
+| Belice | x | | {blank}footnote:res[] | 15
+| Benin (República de) | x | | {blank}footnote:res[] | 15
+| Bermudas | x | | {blank}footnote:res[] | 38
+| Bhután (Reino de) | x | | {blank}footnote:res[] | 15
+| Bolivia (Estado Plurinacional de) | x | | {blank}footnote:res[] | 16
+| Bonaire, San Eustatius y Saba | x | | {blank}footnote:res[] | 16
+| Bosnia y Herzegovina | x | | {blank}footnote:res[] |
+| Botswana (República de) | x | | {blank}footnote:res[] | 16
+| Bouvet Isla | x | | {blank}footnote:res[] | 34
+| Brasil (República Federativa del) | x | | {blank}footnote:res[] | 16-17
+| Brunei Darussalam | x | | {blank}footnote:res[] | 17
+| Bulgaria (República de) | x | | {blank}footnote:res[] | 17
+| Burkina Faso | x | | {blank}footnote:res[] | 17
+| Burundi (República de) | x | | {blank}footnote:res[] | 18
+| Cabo Verde (República de) | x | | {blank}footnote:res[] | 18
+| Caimanes (Islas) | x | | {blank}footnote:res[] | 38
+| Camboya (Reino de) | x | | {blank}footnote:res[] |
+| Camerún (República de) | x | | {blank}footnote:res[] | 18
+| Canadá | x | | {blank}footnote:res[] | 18
+| Canarias (Islas) | x | | {blank}footnote:res[] | 21
+| Centroafricana (República) | x | | {blank}footnote:res[] | 18
+| Ciudad del Vaticano (Estado de la) | x | | {blank}footnote:res[] | 18
+| Clipperton Isla | x | | {blank}footnote:res[] | 24
+| Cocos (Keeling) (Islas) | x | | | 13
+| Colombia (República de) | x | | {blank}footnote:res[] | 18
+| Comoras (Unión de las) | x | | {blank}footnote:res[] | 19
+| Congo (República del) | x | | {blank}footnote:res[] | 19
+| Cook (Islas) | x | | {blank}footnote:res[] | 19
+| Corea (República de) | x | | {blank}footnote:res[] | 19
+| Costa Rica | x | | {blank}footnote:res[] | 19
+| Côte d'Ivoire (República de) | x | | {blank}footnote:res[] | 19
+| Croacia (República de) | x | | {blank}footnote:res[] | 19
+| Crozet (Archipiélago) | x | | {blank}footnote:res[] | 24
+| Cuba | x | | {blank}footnote:res[] | 19
+| Curaçao | x | | {blank}footnote:res[] | 19
+| Chad (República del) | x | | {blank}footnote:res[] | 20
+| Chagos (Islas) (Océano Índico) | x | | {blank}footnote:res[] | 38
+| Chile | x | | {blank}footnote:res[] | 20
+| China (República Popular de) | x | | {blank}footnote:res[] |
+| Chipre (República de) | x | | {blank}footnote:res[] | 20
+| Christmas (Isla) (Océano Índico) | x | | | 13
+| Diego García | x | | {blank}footnote:res[] | 38
+| Dinamarca | x | | {blank}footnote:res[] | 20
+| Djibouti (República de) | x | | {blank}footnote:res[] | 20
+| Dominica (Commonwealth de) | x | | {blank}footnote:res[] | 20
+| Dominicana (República) | x | | {blank}footnote:res[] | 20
+| Ecuador | x | | {blank}footnote:res[] | 21
+| Egipto (República Árabe de) | x | | {blank}footnote:res[] | 21
+| El Salvador (República de) | x | | {blank}footnote:res[] | 21
+| Emiratos Árabes Unidos | x | | {blank}footnote:res[] | 21
+| Eritrea | | x | {blank}footnote:res[] |
+| Eslovenia (República de) | x | | {blank}footnote:res[] | 21
+| España | x | | {blank}footnote:res[] | 21
+| Estados Unidos de América | x | | {blank}footnote:res[] | 22
+| Estonia (República de) | x | | {blank}footnote:res[] | 22
+| Etiopía (República Democrática Federal de) | x | | {blank}footnote:res[] | 22
+| Federación de Rusia | x | | {blank}footnote:res[] | 23
+| Feroe (Islas) | x | | {blank}footnote:res[] | 20
+| Fiji (República de) | x | | {blank}footnote:res[] | 23
+| Filipinas (República de) | x | | {blank}footnote:res[] | 24
+| Finlandia | x | | {blank}footnote:res[] | 24
+| Francia | x | | {blank}footnote:res[] | 24
+| Gabonesa (República) | x | | {blank}footnote:res[] | 24
+| Gambia (República de) | x | | {blank}footnote:res[] | 24
+| Georgia | x | | {blank}footnote:res[] | 25
+| Ghana | x | | {blank}footnote:res[] | 25
+| Gibraltar | x | | {blank}footnote:res[] | 38
+| Granada | x | | {blank}footnote:res[] |
+| Grecia | x | | {blank}footnote:res[] | 25
+| Groenlandia | x | | {blank}footnote:res[] | 20
+| Guadalupe (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| Guam | x | | {blank}footnote:res[] | 22
+| Guatemala (República de) | x | | {blank}footnote:res[] | 25
+| Guayana (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| Guinea (República de) | x | | {blank}footnote:res[] | 25
+| Guinea Ecuatorial (República de) | x | | {blank}footnote:res[] |
+| Guinea-Bissau (República de) | x | | {blank}footnote:res[] | 26
+| Guyana | x | | {blank}footnote:res[] | 26
+| Haití (República de) | x | | {blank}footnote:res[] | 26
+| Hawai (Estado de) | x | | {blank}footnote:res[] | 22
+| Heard y McDonald Islas | x | | | 13
+| Honduras (República de) | x | | {blank}footnote:res[] | 26
+| Hong Kong (Región administrativa especial de China) | | | {blank}footnote:res[] |
+| Howland (Isla) | x | | {blank}footnote:res[] | 22
+| Hungría | x | | {blank}footnote:res[] | 26
+| India (República de la) | x | | {blank}footnote:res[] | 26
+| Indonesia (República de) | x | | {blank}footnote:res[] | 26
+| Irán (República Islámica del) | x | | {blank}footnote:res[] | 26
+| Iraq (República del) | x | | {blank}footnote:res[] | 27
+| Irlanda | x | | {blank}footnote:res[] | 27
+| Islandia | x | | {blank}footnote:res[] | 27
+| Israel (Estado de) | x | | {blank}footnote:res[] | 27
+| Italia | x | | {blank}footnote:res[] | 27-28
+| Jamaica | x | | {blank}footnote:res[] | 28
+| Japón | x | | {blank}footnote:res[] | 28
+| Jarvis (Isla) | x | | {blank}footnote:res[] | 22
+| Johnston (Isla) | x | | {blank}footnote:res[] | 22
+| Jordania (Reino Hachemita de) | x | | {blank}footnote:res[] | 28
+| Kazajstán (República de) | x | | {blank}footnote:res[] |
+| Kenya (República de) | x | | {blank}footnote:res[] | 28
+| Kerguelén (Islas) | x | | {blank}footnote:res[] | 24
+| Kiribati (República de) | x | | {blank}footnote:res[] | 29
+| Kuwait (Estado de) | x | | {blank}footnote:res[] | 29
+| La ex República Yugoslava de Macedonia | x | | {blank}footnote:res[] |
+| Lao (República Democrática Popular) | x | | {blank}footnote:res[] | 29
+| Lesotho (Reino de) | x | | {blank}footnote:res[] | 29
+| Letonia (República de) | x | | {blank}footnote:res[] | 29
+| Líbano | x | | Excepto Israel | 29
+| Liberia (República de) | x | | {blank}footnote:res[] |
+| Libia | x | | {blank}footnote:res[] | 29
+| Liechtenstein (Principado de) | x | | {blank}footnote:res[] | 29
+| Lituania (República de) | x | | {blank}footnote:res[] | 29
+| Luxemburgo | x | | {blank}footnote:res[] | 30
+| Macao (Región administrativa especial de China) | x | | {blank}footnote:res[] |
+| Madagascar (República de) | x | | {blank}footnote:res[] | 30
+| Madeira | x | | {blank}footnote:res[] | 36
+| Malasia | x | | {blank}footnote:res[] | 30
+| Malawi | x | | {blank}footnote:res[] | 30
+| Maldivas (República de) | x | | {blank}footnote:res[] | 30
+| Malí (República de) | x | | {blank}footnote:res[] |
+| Malta | x | | {blank}footnote:res[] | 31
+| Malvinas (Islas) (Falkland) | x | | {blank}footnote:res[] | 38
+| Marianas del Norte (Islas) (Commonwealth de las) | x | | {blank}footnote:res[] | 22
+| Marión (Isla) | x | | {blank}footnote:res[] | 41
+| Marruecos (Reino de) | x | | {blank}footnote:res[] | 31
+| Marshall (República de las Islas) | x | | {blank}footnote:res[] |
+| Martinica (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| Mauricio (República de) | x | | {blank}footnote:res[] | 31
+| Mauritania (República Islámica de) | x | | {blank}footnote:res[] | 31
+| Mayotte (Colectividad territorial de). | x | | {blank}footnote:res[] | 24
+| México. | x | | {blank}footnote:res[] | 31
+| Micronesia (Estados federados de) | x | | {blank}footnote:res[] | 32
+| Midway (Islas) | x | | {blank}footnote:res[] | 22
+| Moldova (República de). | x | | {blank}footnote:res[] | 32
+| Mónaco (Principado de) | x | | {blank}footnote:res[] | 32
+| Mongolia | x | | {blank}footnote:res[] |
+| Montenegro | x | | {blank}footnote:res[] |
+| Montserrat | x | | {blank}footnote:res[] | 38
+| Mozambique (República de) | x | | {blank}footnote:res[] | 32
+| Myanmar (Unión de) | x | | {blank}footnote:res[] | 32
+| Namibia (República de) | x | | {blank}footnote:res[] | 33
+| Nauru (República de) | x | | {blank}footnote:res[] | 33
+| Nepal (República Democrática Federal de) | x | | {blank}footnote:res[] | 33
+| Nicaragua | x | | {blank}footnote:res[] | 33
+| Níger (República del) | x | | {blank}footnote:res[] | 33
+| Nigeria (República Federal de) | x | | {blank}footnote:res[] | 33
+| Niue | x | | {blank}footnote:res[] | 34
+| Norfolk (Isla) | x | | | 13
+| Noruega | x | | {blank}footnote:res[] | 34
+| Nueva Caledonia | x | | {blank}footnote:res[] | 24
+| Nueva Zelandia | x | | {blank}footnote:res[] | 34
+| Omán (Sultanía de) | x | | {blank}footnote:res[] | 34
+| Países Bajos (Reino de los) | x | | {blank}footnote:res[] | 35
+| Pakistán (República Islámica del) | x | | {blank}footnote:res[] | 35
+| Palau (República de) | x | | {blank}footnote:res[] |
+| Palmira (Isla) | x | | {blank}footnote:res[] | 22
+| Panamá (República de) | x | | {blank}footnote:res[] |
+| Papua Nueva Guinea | x | | {blank}footnote:res[] | 35
+| Paraguay (República del) | x | | {blank}footnote:res[] | 35
+| Pascua (Isla de) | x | | {blank}footnote:res[] | 20
+| Perú | x | | {blank}footnote:res[] | 35
+| Phoenix (Islas) | x | | {blank}footnote:res[] | 29
+| Pitcairn (Isla) | x | | {blank}footnote:res[] | 38
+| Polinesia francesa | x | | {blank}footnote:res[] | 24
+| Polonia (República de) | x | | {blank}footnote:res[] | 35-36
+| Portugal | x | | {blank}footnote:res[] | 36-37
+| Puerto Rico | x | | {blank}footnote:res[] | 22
+| Qatar (Estado de) | x | | {blank}footnote:res[] | 37
+| Reino Unido de Gran Bretaña e Irlanda del Norte | x | | {blank}footnote:res[] | 37-38
+| República Árabe Siria | x | | Excepto Israel | 39
+| República Checa | x | | {blank}footnote:res[] | 39
+| República Democrática del Congo | x | | {blank}footnote:res[] |
+| República Eslovaca | x | | {blank}footnote:res[] | 39
+| República Kirguisa | x | | {blank}footnote:res[] | 39
+| República Popular Democrática de Corea | | x | {blank}footnote:res[] |
+| Reunión (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| Rodrígues | x | | {blank}footnote:res[] | 31
+| Rumania | x | | {blank}footnote:res[] | 39
+| Rwanda (República de) | x | | {blank}footnote:res[] | 40
+| Saint Kitts y Nevis (Federación de) | x | | {blank}footnote:res[] |
+| Salomón (Islas) | x | | {blank}footnote:res[] | 40
+| Samoa (Estado Independiente de) | x | | {blank}footnote:res[] | 40
+| Samoa norteamericanas | x | | {blank}footnote:res[] | 22
+| San Bartolomé (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| San Maarten (parte neerlandesa) | x | | {blank}footnote:res[] | 40
+| San Marino (República de) | x | | {blank}footnote:res[] | 40
+| San Martín (Departamento francés de la) | x | | {blank}footnote:res[] | 24
+| San Paul y Amsterdam (Islas) | x | | {blank}footnote:res[] | 24
+| San Pedro y Miquelón (Colectividad territorial de) | x | | {blank}footnote:res[] | 24
+| San Vicente y las Granadinas | x | | {blank}footnote:res[] |
+| Santa Elena | x | | {blank}footnote:res[] | 38
+| Santa Lucía | x | | {blank}footnote:res[] |
+| Santo Tomé y Príncipe (República Democrática de) | x | | {blank}footnote:res[] | 40
+| Senegal (República del) | x | | {blank}footnote:res[] | 40
+| Serbia (República de) | x | | {blank}footnote:res[] |
+| Seychelles (República de) | x | | {blank}footnote:res[] | 40
+| Sierra Leona | x | | {blank}footnote:res[] | 40
+| Singapur (República de) | x | | {blank}footnote:res[] | 41
+| Somalia (República Federal de) | x | | {blank}footnote:res[] |
+| Sri Lanka (República Socialista Democrática de) | x | | {blank}footnote:res[] | 41
+| Sudafricana (República) | x | | {blank}footnote:res[] | 41
+| Sudán (República del) | x | | {blank}footnote:res[] |
+| Sudán del Sur (República de) | x | | {blank}footnote:res[] |
+| Suecia | x | | {blank}footnote:res[] | 41
+| Suiza (Confederación) | x | | {blank}footnote:res[] | 41
+| Suriname (República de) | x | | {blank}footnote:res[] | 41
+| Swan (Islas) | x | | {blank}footnote:res[] | 26
+| Swazilandia (Reino de) | x | | {blank}footnote:res[] | 41
+| Tailandia | x | | {blank}footnote:res[] | 42
+| Tanzanía (República Unida de) | x | | {blank}footnote:res[] | 42
+| Tayikistán (República de) | x | | {blank}footnote:res[] |
+| Timor-Leste (República Democrática de) | x | | {blank}footnote:res[] |
+| Togolesa (República) | x | | {blank}footnote:res[] |
+| Tokelau | x | | {blank}footnote:res[] | 34
+| Tonga (Reino de) | x | | {blank}footnote:res[] | 42
+| Trinidad y Tabago | x | | {blank}footnote:res[] | 42
+| Tristán da Cunha | x | | {blank}footnote:res[] | 38
+| Túnez | x | | {blank}footnote:res[] | 42
+| Turkmenistán | x | | {blank}footnote:res[] |
+| Turquesas y Caicos (Islas) | x | | {blank}footnote:res[] | 38
+| Turquía | x | | {blank}footnote:res[] | 42
+| Tuvalu | x | | {blank}footnote:res[] | 42
+| Ucrania | x | | {blank}footnote:res[] | 43
+| Uganda (República de) | x | | {blank}footnote:res[] | 43
+| Uruguay (República Oriental del) | x | | {blank}footnote:res[] | 43
+| Uzbekistán (República de) | x | | {blank}footnote:res[] |
+| Vanuatu (República de) | x | | {blank}footnote:res[] | 43
+| Venezuela (República Bolivariana de) | x | | {blank}footnote:res[] | 43
+| Viet Nam (República Socialista de) | x | | Excepto entre estaciones del servicio de aficionados por satélite | 43
+| Vírgenes americanas (Islas) | x | | {blank}footnote:res[] | 22
+| Vírgenes británicas (Islas) | x | | {blank}footnote:res[] | 38
+| Wake (Isla) | x | | {blank}footnote:res[] | 22
+| Wallis y Futuna (Islas) | x | | {blank}footnote:res[] | 24
+| Yemen (República del) | x | | {blank}footnote:res[] |
+| Zambia (República de) | x | | {blank}footnote:res[] | 43
+| Zimbabwe (República de) | x | | {blank}footnote:res[] | 43
 
 |===
 


### PR DESCRIPTION
Fixes https://github.com/ituob/service-publications-docs/issues/37

Documents from `1154-RR.25.1/` were failling due to a markup issue in the tables.
I have made general markup updates to the three versions: eng, fr, sp.